### PR TITLE
Added FLATBUFFERS_FOUND to FlatBufferConfig.cmake

### DIFF
--- a/CMake/FlatBuffersConfig.cmake.in
+++ b/CMake/FlatBuffersConfig.cmake.in
@@ -12,6 +12,7 @@ endif ()
 #-----------------------------------------------------------------------------
 set(FlatBuffers_INCLUDE_DIRS @FLATBUFFERS_INCLUDE_DIRS@)
 set(FlatBuffers_FOUND 1)
+set(FLATBUFFERS_FOUND 1) # Added for compatibility
 
 # these are for compatibility with older cmake scripts
 set(FlatBuffers_INCLUDE_DIR  @FLATBUFFERS_INCLUDE_DIRS@)


### PR DESCRIPTION
This is the casing that some projects expect downstream (e.g. zeq).